### PR TITLE
Improve logging

### DIFF
--- a/kyoka/algorithm/base_rl_algorithm.py
+++ b/kyoka/algorithm/base_rl_algorithm.py
@@ -29,7 +29,8 @@ class BaseRLAlgorithm(object):
   def run_gpi(self, nb_iteration, finish_rules=[], callbacks=[], verbose=1):
     callbacks = self.__wrap_item_if_single(callbacks)
     finish_rules = self.__wrap_item_if_single(finish_rules)
-    finish_rules.append(WatchIterationCount(nb_iteration, log_interval=float('inf') if verbose==0 else 1))
+    default_finish_rule = WatchIterationCount(nb_iteration, log_interval=float('inf') if verbose==0 else 1)
+    finish_rules.append(default_finish_rule)
     [finish_rule.log_start_message() for finish_rule in finish_rules]
     [callback.before_gpi_start(self.domain, self.value_function) for callback in callbacks]
 
@@ -42,6 +43,7 @@ class BaseRLAlgorithm(object):
       for finish_rule in finish_rules:
         if finish_rule.satisfy_condition(iteration_counter):
           [callback.after_gpi_finish(self.domain, self.value_function) for callback in callbacks]
+          default_finish_rule.log_finish_message(iteration_counter)
           return
 
   def generate_episode(self, domain, value_function, policy):

--- a/kyoka/algorithm/base_rl_algorithm.py
+++ b/kyoka/algorithm/base_rl_algorithm.py
@@ -26,10 +26,10 @@ class BaseRLAlgorithm(object):
     err_msg = self.__build_err_msg("update_value_function")
     raise NotImplementedError(err_msg)
 
-  def run_gpi(self, nb_iteration, finish_rules=[], callbacks=[]):
+  def run_gpi(self, nb_iteration, finish_rules=[], callbacks=[], verbose=1):
     callbacks = self.__wrap_item_if_single(callbacks)
     finish_rules = self.__wrap_item_if_single(finish_rules)
-    finish_rules.append(WatchIterationCount(nb_iteration))
+    finish_rules.append(WatchIterationCount(nb_iteration, log_interval=float('inf') if verbose==0 else 1))
     [finish_rule.log_start_message() for finish_rule in finish_rules]
     [callback.before_gpi_start(self.domain, self.value_function) for callback in callbacks]
 

--- a/kyoka/algorithm/base_rl_algorithm.py
+++ b/kyoka/algorithm/base_rl_algorithm.py
@@ -43,7 +43,8 @@ class BaseRLAlgorithm(object):
       for finish_rule in finish_rules:
         if finish_rule.satisfy_condition(iteration_counter):
           [callback.after_gpi_finish(self.domain, self.value_function) for callback in callbacks]
-          default_finish_rule.log_finish_message(iteration_counter)
+          if finish_rule != default_finish_rule:
+            default_finish_rule.log_finish_message(iteration_counter)
           return
 
   def generate_episode(self, domain, value_function, policy):

--- a/kyoka/algorithm/base_rl_algorithm.py
+++ b/kyoka/algorithm/base_rl_algorithm.py
@@ -30,8 +30,10 @@ class BaseRLAlgorithm(object):
     callbacks = self.__wrap_item_if_single(callbacks)
     finish_rules = self.__wrap_item_if_single(finish_rules)
     finish_rules.append(WatchIterationCount(nb_iteration))
-    iteration_counter = 0
+    [finish_rule.log_start_message() for finish_rule in finish_rules]
     [callback.before_gpi_start(self.domain, self.value_function) for callback in callbacks]
+
+    iteration_counter = 0
     while True:
       [callback.before_update(iteration_counter, self.domain, self.value_function) for callback in callbacks]
       self.update_value_function(self.domain, self.policy, self.value_function)

--- a/kyoka/algorithm/base_rl_algorithm.py
+++ b/kyoka/algorithm/base_rl_algorithm.py
@@ -39,9 +39,8 @@ class BaseRLAlgorithm(object):
       iteration_counter += 1
       for finish_rule in finish_rules:
         if finish_rule.satisfy_condition(iteration_counter):
-          finish_msg = finish_rule.generate_finish_message(iteration_counter)
           [callback.after_gpi_finish(self.domain, self.value_function) for callback in callbacks]
-          return finish_msg
+          return
 
   def generate_episode(self, domain, value_function, policy):
     state = domain.generate_initial_state()

--- a/kyoka/finish_rule/base_finish_rule.py
+++ b/kyoka/finish_rule/base_finish_rule.py
@@ -10,6 +10,9 @@ class BaseFinishRule(object):
     self.__notify_message_if_needed(is_satisfied, iteration_count)
     return is_satisfied
 
+  def log_start_message(self):
+    self.__log(self.generate_start_message())
+
   def log_progress(self, iteration_count):
     self.__log(self.generate_progress_message(iteration_count))
 
@@ -26,6 +29,10 @@ class BaseFinishRule(object):
 
   def check_condition(self, iteration_count):
     err_msg = self.__build_err_msg("check_condition")
+    raise NotImplementedError(err_msg)
+
+  def generate_start_message(self):
+    err_msg = self.__build_err_msg("generate_start_message")
     raise NotImplementedError(err_msg)
 
   def generate_progress_message(self, iteration_count):

--- a/kyoka/finish_rule/base_finish_rule.py
+++ b/kyoka/finish_rule/base_finish_rule.py
@@ -1,7 +1,7 @@
 
 class BaseFinishRule(object):
 
-  def __init__(self, log_interval=100):
+  def __init__(self, log_interval=1):
     self.log_interval = log_interval
     self.log_interval_counter = 0
 

--- a/kyoka/finish_rule/base_finish_rule.py
+++ b/kyoka/finish_rule/base_finish_rule.py
@@ -1,4 +1,3 @@
-import logging
 
 class BaseFinishRule(object):
 
@@ -10,6 +9,20 @@ class BaseFinishRule(object):
     is_satisfied = self.check_condition(iteration_count)
     self.__notify_message_if_needed(is_satisfied, iteration_count)
     return is_satisfied
+
+  def log_progress(self, iteration_count):
+    self.__log(self.generate_progress_message(iteration_count))
+
+  def log_finish_message(self, iteration_count):
+    self.__log(self.generate_finish_message(iteration_count))
+
+  def define_log_tag(self):
+    err_msg = self.__build_err_msg("define_log_tag")
+    raise NotImplementedError(err_msg)
+
+  def check_condition(self, iteration_count):
+    err_msg = self.__build_err_msg("check_condition")
+    raise NotImplementedError(err_msg)
 
   def check_condition(self, iteration_count):
     err_msg = self.__build_err_msg("check_condition")
@@ -26,9 +39,9 @@ class BaseFinishRule(object):
   def __notify_message_if_needed(self, is_satisfied_condition, iteration_count):
     self.log_interval_counter += 1
     if is_satisfied_condition:
-      self.__log(self.generate_finish_message(iteration_count))
+      self.log_finish_message(iteration_count)
     elif self.log_interval_counter >= self.log_interval:
-      self.__log(self.generate_progress_message(iteration_count))
+      self.log_progress(iteration_count)
       self.log_interval_counter = 0
 
   def __build_err_msg(self, msg):
@@ -37,5 +50,5 @@ class BaseFinishRule(object):
 
   def __log(self, message):
     if message and len(message) != 0:
-      logging.info(message)
+      print "[%s] %s" % (self.define_log_tag(), message)
 

--- a/kyoka/finish_rule/manual_interruption.py
+++ b/kyoka/finish_rule/manual_interruption.py
@@ -15,6 +15,9 @@ class ManualInterruption(BaseFinishRule):
   def check_condition(self, _iteration_count):
     return self.__order_found_in_monitoring_file(self.monitor_file_path, self.TARGET_WARD)
 
+  def generate_start_message(self):
+    return 'Write word "%s" on file "%s" will finish the GPI' % (self.TARGET_WARD, self.monitor_file_path)
+
   def generate_progress_message(self, _iteration_count):
     return None
 

--- a/kyoka/finish_rule/manual_interruption.py
+++ b/kyoka/finish_rule/manual_interruption.py
@@ -9,6 +9,9 @@ class ManualInterruption(BaseFinishRule):
     BaseFinishRule.__init__(self, log_interval)
     self.monitor_file_path = monitor_file_path
 
+  def define_log_tag(self):
+    return "ManualInterruption"
+
   def check_condition(self, _iteration_count):
     return self.__order_found_in_monitoring_file(self.monitor_file_path, self.TARGET_WARD)
 

--- a/kyoka/finish_rule/watch_iteration_count.py
+++ b/kyoka/finish_rule/watch_iteration_count.py
@@ -6,6 +6,9 @@ class WatchIterationCount(BaseFinishRule):
     BaseFinishRule.__init__(self, log_interval)
     self.target_count = target_count
 
+  def define_log_tag(self):
+    return "Progress"
+
   def check_condition(self, iteration_count):
     return iteration_count >= self.target_count
 

--- a/kyoka/finish_rule/watch_iteration_count.py
+++ b/kyoka/finish_rule/watch_iteration_count.py
@@ -12,6 +12,9 @@ class WatchIterationCount(BaseFinishRule):
   def check_condition(self, iteration_count):
     return iteration_count >= self.target_count
 
+  def generate_start_message(self):
+    return "Start GPI iteration for %d times" % self.target_count
+
   def generate_progress_message(self, iteration_count):
     base_msg = "Finished %d / %d iterations"
     return base_msg % (iteration_count, self.target_count)

--- a/kyoka/finish_rule/watch_iteration_count.py
+++ b/kyoka/finish_rule/watch_iteration_count.py
@@ -1,3 +1,4 @@
+import time
 from kyoka.finish_rule.base_finish_rule import BaseFinishRule
 
 class WatchIterationCount(BaseFinishRule):
@@ -5,6 +6,7 @@ class WatchIterationCount(BaseFinishRule):
   def __init__(self, target_count, log_interval=100):
     BaseFinishRule.__init__(self, log_interval)
     self.target_count = target_count
+    self.last_update_time = 0
 
   def define_log_tag(self):
     return "Progress"
@@ -13,11 +15,15 @@ class WatchIterationCount(BaseFinishRule):
     return iteration_count >= self.target_count
 
   def generate_start_message(self):
+    self.last_update_time = time.time()
     return "Start GPI iteration for %d times" % self.target_count
 
   def generate_progress_message(self, iteration_count):
-    base_msg = "Finished %d / %d iterations"
-    return base_msg % (iteration_count, self.target_count)
+    current_time = time.time()
+    msg = "Finished %d / %d iterations (%.1fs)" %\
+            (iteration_count, self.target_count, current_time - self.last_update_time)
+    self.last_update_time = current_time
+    return msg
 
   def generate_finish_message(self, iteration_count):
     base_msg = "Completed GPI iteration for %d times."

--- a/kyoka/finish_rule/watch_iteration_count.py
+++ b/kyoka/finish_rule/watch_iteration_count.py
@@ -3,7 +3,7 @@ from kyoka.finish_rule.base_finish_rule import BaseFinishRule
 
 class WatchIterationCount(BaseFinishRule):
 
-  def __init__(self, target_count, log_interval=100):
+  def __init__(self, target_count, log_interval=1):
     BaseFinishRule.__init__(self, log_interval)
     self.target_count = target_count
     self.start_time = self.last_update_time = 0

--- a/kyoka/finish_rule/watch_iteration_count.py
+++ b/kyoka/finish_rule/watch_iteration_count.py
@@ -6,7 +6,7 @@ class WatchIterationCount(BaseFinishRule):
   def __init__(self, target_count, log_interval=100):
     BaseFinishRule.__init__(self, log_interval)
     self.target_count = target_count
-    self.last_update_time = 0
+    self.start_time = self.last_update_time = 0
 
   def define_log_tag(self):
     return "Progress"
@@ -15,7 +15,7 @@ class WatchIterationCount(BaseFinishRule):
     return iteration_count >= self.target_count
 
   def generate_start_message(self):
-    self.last_update_time = time.time()
+    self.start_time = self.last_update_time = time.time()
     return "Start GPI iteration for %d times" % self.target_count
 
   def generate_progress_message(self, iteration_count):
@@ -26,8 +26,8 @@ class WatchIterationCount(BaseFinishRule):
     return msg
 
   def generate_finish_message(self, iteration_count):
-    base_msg = "Completed GPI iteration for %d times."
-    return base_msg % iteration_count
+    base_msg = "Completed GPI iteration for %d times. (total time: %ds)"
+    return base_msg % (iteration_count, time.time() - self.start_time)
 
   def __build_err_msg(self, msg):
     base_msg = "[ {0} ] class does not implement [ {1} ] method"

--- a/tests/kyoka/algorithm/base_rl_algorithm_test.py
+++ b/tests/kyoka/algorithm/base_rl_algorithm_test.py
@@ -68,9 +68,9 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     value_func = self.__setup_stub_value_function()
     algo.setUp(domain, policy, value_func)
     finish_rule = self.TestFinishRule()
-    algo.run_gpi(nb_iteration="dummy", finish_rules=finish_rule)
+    algo.run_gpi(nb_iteration=2, finish_rules=finish_rule)
     expected = "[test_tag] finish:2\n"
-    self.eq(expected, self.capture.getvalue())
+    self.true(self.capture.getvalue().endswith(expected))
 
   def test_GPI_with_multiple_finish_rules(self):
     algo = self.TestImplementation()
@@ -81,10 +81,10 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     finish_rule1 = self.TestFinishRule([False, True])
     finish_rule2 = self.TestFinishRule([True, False])
     finish_rules = [finish_rule1, finish_rule2]
-    finish_msg = algo.run_gpi(nb_iteration="dummy", finish_rules=finish_rules)
+    finish_msg = algo.run_gpi(nb_iteration=2, finish_rules=finish_rules)
     expected = 1
     expected = "[test_tag] finish:1\n"
-    self.eq(expected, self.capture.getvalue())
+    self.true(self.capture.getvalue().endswith(expected))
 
   def test_set_callback(self):
     algo = self.TestImplementation()
@@ -92,7 +92,7 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     algo.setUp("domain", "dummy", value_func)
     callback = Mock()
     finish_rule = self.TestFinishRule()
-    finish_msg = algo.run_gpi(nb_iteration="dummy", finish_rules=finish_rule, callbacks=callback)
+    finish_msg = algo.run_gpi(nb_iteration=2, finish_rules=finish_rule, callbacks=callback)
     self.eq(1, callback.before_gpi_start.call_count)
     self.eq(2, callback.before_update.call_count)
     self.eq(2, callback.after_update.call_count)
@@ -137,6 +137,9 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     def check_condition(self, iteration_count):
       self.return_idx += 1
       return self.return_value[self.return_idx-1]
+
+    def generate_start_message(self):
+      return ""
 
     def generate_progress_message(self, iteration_count):
       return "%s:%s" % ("progress", iteration_count)

--- a/tests/kyoka/algorithm/base_rl_algorithm_test.py
+++ b/tests/kyoka/algorithm/base_rl_algorithm_test.py
@@ -115,6 +115,15 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     expected = "[Progress] Completed"
     self.include(expected, self.capture.getvalue())
 
+  def test_not_to_log_duplicated_default_finish_message(self):
+    algo = self.TestImplementation()
+    domain = self.__setup_stub_domain()
+    policy = GreedyPolicy()
+    value_func = self.__setup_stub_value_function()
+    algo.setUp(domain, policy, value_func)
+    algo.run_gpi(nb_iteration=2)
+    self.eq(1, self.capture.getvalue().count("[Progress] Completed"))
+
   def test_set_callback(self):
     algo = self.TestImplementation()
     value_func = Mock(name="value_func")

--- a/tests/kyoka/algorithm/base_rl_algorithm_test.py
+++ b/tests/kyoka/algorithm/base_rl_algorithm_test.py
@@ -70,7 +70,7 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     finish_rule = self.TestFinishRule()
     algo.run_gpi(nb_iteration=2, finish_rules=finish_rule)
     expected = "[test_tag] finish:2\n"
-    self.true(self.capture.getvalue().endswith(expected))
+    self.include(expected, self.capture.getvalue())
 
   def test_GPI_with_multiple_finish_rules(self):
     algo = self.TestImplementation()
@@ -84,7 +84,7 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     finish_msg = algo.run_gpi(nb_iteration=2, finish_rules=finish_rules)
     expected = 1
     expected = "[test_tag] finish:1\n"
-    self.true(self.capture.getvalue().endswith(expected))
+    self.include(expected, self.capture.getvalue())
 
   def test_verbose_mode(self):
     algo = self.TestImplementation()
@@ -102,6 +102,18 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     sys.stdout = capture
     algo.run_gpi(nb_iteration=2, finish_rules=self.TestFinishRule(), verbose=0)
     self.not_include("[Progress] Finished", capture.getvalue())
+
+  def test_defult_finish_message_must_be_logged(self):
+    algo = self.TestImplementation()
+    domain = self.__setup_stub_domain()
+    policy = GreedyPolicy()
+    value_func = self.__setup_stub_value_function()
+    algo.setUp(domain, policy, value_func)
+    finish_rule = self.TestFinishRule()
+    algo.run_gpi(nb_iteration=2, finish_rules=finish_rule)
+
+    expected = "[Progress] Completed"
+    self.include(expected, self.capture.getvalue())
 
   def test_set_callback(self):
     algo = self.TestImplementation()

--- a/tests/kyoka/algorithm/base_rl_algorithm_test.py
+++ b/tests/kyoka/algorithm/base_rl_algorithm_test.py
@@ -86,6 +86,23 @@ class BaseRLAlgorithmTest(BaseUnitTest):
     expected = "[test_tag] finish:1\n"
     self.true(self.capture.getvalue().endswith(expected))
 
+  def test_verbose_mode(self):
+    algo = self.TestImplementation()
+    domain = self.__setup_stub_domain()
+    policy = GreedyPolicy()
+    value_func = self.__setup_stub_value_function()
+    algo.setUp(domain, policy, value_func)
+
+    capture = StringIO.StringIO()
+    sys.stdout = capture
+    algo.run_gpi(nb_iteration=2, finish_rules=self.TestFinishRule())
+    self.include("[Progress] Finished", capture.getvalue())
+
+    capture = StringIO.StringIO()
+    sys.stdout = capture
+    algo.run_gpi(nb_iteration=2, finish_rules=self.TestFinishRule(), verbose=0)
+    self.not_include("[Progress] Finished", capture.getvalue())
+
   def test_set_callback(self):
     algo = self.TestImplementation()
     value_func = Mock(name="value_func")

--- a/tests/kyoka/finish_rule/base_finish_rule_test.py
+++ b/tests/kyoka/finish_rule/base_finish_rule_test.py
@@ -32,6 +32,11 @@ class BaseFinishRuleTest(BaseUnitTest):
     self.true(rule.satisfy_condition(0))
     self.eq('[test_tag] finish:0\n', self.capture.getvalue())
 
+  def test_log_start_message(self):
+    rule = self.TestImplementation()
+    rule.log_start_message()
+    self.eq('[test_tag] start\n', self.capture.getvalue())
+
   def test_log_progress(self):
     rule = self.TestImplementation()
     rule.log_progress(1)
@@ -65,6 +70,9 @@ class BaseFinishRuleTest(BaseUnitTest):
 
     def check_condition(self, iteration_count):
       return iteration_count == 0
+
+    def generate_start_message(self):
+      return "start"
 
     def generate_progress_message(self, iteration_count):
       return "%s:%s" % ("progress", iteration_count)

--- a/tests/kyoka/finish_rule/base_finish_rule_test.py
+++ b/tests/kyoka/finish_rule/base_finish_rule_test.py
@@ -4,22 +4,47 @@ from kyoka.finish_rule.base_finish_rule import BaseFinishRule
 from nose.tools import raises
 from mock import patch
 
+import StringIO
+import sys
+
 class BaseFinishRuleTest(BaseUnitTest):
 
   def setUp(self):
     self.rule = BaseFinishRule()
+    self.capture = StringIO.StringIO()
+    sys.stdout = self.capture
+
+  def tearDown(self):
+    sys.stdout = sys.__stdout__
 
   def test_satisfy_condition_logging(self):
     rule = self.TestImplementation(log_interval=2)
-    with patch("logging.info") as log_mock:
-      self.false(rule.satisfy_condition(1))
-      log_mock.assert_not_called()
-      self.false(rule.satisfy_condition(2))
-      log_mock.assert_called_with("progress:2")
-      self.false(rule.satisfy_condition(3))
-      log_mock.assert_called_with("progress:2")
-      self.true(rule.satisfy_condition(0))
-      log_mock.assert_called_with("finish:0")
+    self.false(rule.satisfy_condition(1))
+    self.eq('', self.capture.getvalue())
+    self.false(rule.satisfy_condition(2))
+    self.eq('[test_tag] progress:2\n', self.capture.getvalue())
+    self.capture = StringIO.StringIO()
+    sys.stdout = self.capture
+    self.false(rule.satisfy_condition(3))
+    self.eq('', self.capture.getvalue())
+    self.capture = StringIO.StringIO()
+    sys.stdout = self.capture
+    self.true(rule.satisfy_condition(0))
+    self.eq('[test_tag] finish:0\n', self.capture.getvalue())
+
+  def test_log_progress(self):
+    rule = self.TestImplementation()
+    rule.log_progress(1)
+    self.eq('[test_tag] progress:1\n', self.capture.getvalue())
+
+  def test_log_finish_message(self):
+    rule = self.TestImplementation()
+    rule.log_finish_message(1)
+    self.eq('[test_tag] finish:1\n', self.capture.getvalue())
+
+  @raises(NotImplementedError)
+  def test_define_log_tag(self):
+    self.rule.define_log_tag()
 
   @raises(NotImplementedError)
   def test_check_condition(self):
@@ -34,6 +59,9 @@ class BaseFinishRuleTest(BaseUnitTest):
     self.rule.generate_finish_message("dummy")
 
   class TestImplementation(BaseFinishRule):
+
+    def define_log_tag(self):
+      return "test_tag"
 
     def check_condition(self, iteration_count):
       return iteration_count == 0

--- a/tests/kyoka/finish_rule/manual_interruption_test.py
+++ b/tests/kyoka/finish_rule/manual_interruption_test.py
@@ -27,6 +27,10 @@ class ManualInterruptionTest(BaseUnitTest):
     self.__write_word(file_path, "stop")
     self.true(self.rule.satisfy_condition(1))
 
+  def test_generate_start_message(self):
+    self.include(self.rule.TARGET_WARD, self.rule.generate_start_message())
+    self.include(self.rule.monitor_file_path, self.rule.generate_start_message())
+
   def test_generate_progress_message(self):
     self.eq(None, self.rule.generate_progress_message(5))
 

--- a/tests/kyoka/finish_rule/manual_interruption_test.py
+++ b/tests/kyoka/finish_rule/manual_interruption_test.py
@@ -16,6 +16,9 @@ class ManualInterruptionTest(BaseUnitTest):
     if os.path.isfile(file_path):
       os.remove(file_path)
 
+  def test_define_log_tag(self):
+    self.eq("ManualInterruption", self.rule.define_log_tag())
+
   def test_satisfy_condition(self):
     file_path = self.__generate_tmp_file_path()
     self.false(self.rule.satisfy_condition(1))

--- a/tests/kyoka/finish_rule/watch_iteration_count_test.py
+++ b/tests/kyoka/finish_rule/watch_iteration_count_test.py
@@ -16,6 +16,9 @@ class BaseFinishRuleTest(BaseUnitTest):
     self.true(self.rule.satisfy_condition(100))
     self.true(self.rule.satisfy_condition(101))
 
+  def test_generat_start_message(self):
+    self.include(str(100), self.rule.generate_start_message())
+
   def test_generate_progress_message(self):
     msg = self.rule.generate_progress_message(5)
     self.include(str(5), msg)

--- a/tests/kyoka/finish_rule/watch_iteration_count_test.py
+++ b/tests/kyoka/finish_rule/watch_iteration_count_test.py
@@ -30,9 +30,15 @@ class BaseFinishRuleTest(BaseUnitTest):
     self.include(str(5), msg)
     self.include(str(100), msg)
 
-  def test_calculation_time_in_prgress_message(self):
+  def test_calculation_time_in_message(self):
     rule = WatchIterationCount(target_count=100, log_interval=1)
-    mock_time_return = [1477394336.834469, 1477394338.815435, 1477394340.965727, 1477394343.925256]
+    mock_time_return = [
+            1477394336.834469,
+            1477394338.815435,
+            1477394340.965727,
+            1477394343.925256,
+            1477394689.794632
+    ]
     expected_calc_time = [1.9809658527374268, 2.150292158126831, 2.959528923034668]
     with patch('time.time', side_effect=mock_time_return):
       rule.log_start_message()
@@ -41,6 +47,12 @@ class BaseFinishRuleTest(BaseUnitTest):
         sys.stdout = capture
         rule.satisfy_condition(1)
         self.include("%.1f" % expected, capture.getvalue())
+
+      expected_total_calc_time = mock_time_return[-1] - mock_time_return[0]
+      capture = StringIO.StringIO()
+      sys.stdout = capture
+      rule.satisfy_condition(100)
+      self.include("%d" % expected_total_calc_time, capture.getvalue())
 
   def test_generate_finish_message(self):
     self.include(str(5), self.rule.generate_finish_message(5))

--- a/tests/kyoka/finish_rule/watch_iteration_count_test.py
+++ b/tests/kyoka/finish_rule/watch_iteration_count_test.py
@@ -1,12 +1,18 @@
 from tests.base_unittest import BaseUnitTest
 from kyoka.finish_rule.watch_iteration_count import WatchIterationCount
 
+import sys
+import StringIO
 from nose.tools import raises
+from mock import patch
 
 class BaseFinishRuleTest(BaseUnitTest):
 
   def setUp(self):
     self.rule = WatchIterationCount(target_count=100)
+
+  def tearDown(self):
+    sys.stdout = sys.__stdout__
 
   def test_define_log_tag(self):
     self.eq("Progress", self.rule.define_log_tag())
@@ -23,6 +29,18 @@ class BaseFinishRuleTest(BaseUnitTest):
     msg = self.rule.generate_progress_message(5)
     self.include(str(5), msg)
     self.include(str(100), msg)
+
+  def test_calculation_time_in_prgress_message(self):
+    rule = WatchIterationCount(target_count=100, log_interval=1)
+    mock_time_return = [1477394336.834469, 1477394338.815435, 1477394340.965727, 1477394343.925256]
+    expected_calc_time = [1.9809658527374268, 2.150292158126831, 2.959528923034668]
+    with patch('time.time', side_effect=mock_time_return):
+      rule.log_start_message()
+      for expected in expected_calc_time:
+        capture = StringIO.StringIO()
+        sys.stdout = capture
+        rule.satisfy_condition(1)
+        self.include("%.1f" % expected, capture.getvalue())
 
   def test_generate_finish_message(self):
     self.include(str(5), self.rule.generate_finish_message(5))

--- a/tests/kyoka/finish_rule/watch_iteration_count_test.py
+++ b/tests/kyoka/finish_rule/watch_iteration_count_test.py
@@ -8,6 +8,9 @@ class BaseFinishRuleTest(BaseUnitTest):
   def setUp(self):
     self.rule = WatchIterationCount(target_count=100)
 
+  def test_define_log_tag(self):
+    self.eq("Progress", self.rule.define_log_tag())
+
   def test_satisfy_condition(self):
     self.false(self.rule.satisfy_condition(99))
     self.true(self.rule.satisfy_condition(100))


### PR DESCRIPTION
original issue https://github.com/ishikota/kyoka/issues/13

```
>> RL_algo.run_gpi(nb_iteration=100, finish_rules=finish_rules)
[ManualInterruption] Write word "stop" on file "~/dev/hoge.txt" will finish the GPI
[Progress] Start GPI iteration for 100 times
[Progress] Finished 1 / 100 iterations (0.6s)
[Progress] Finished 2 / 100 iterations (0.2s)
# ...
[Progress] Finished 98 / 100 iterations (0.0s)
[Progress] Finished 99 / 100 iterations (0.0s)
[Progress] Completed GPI iteration for 100 times. (total time: 3s)
```

TODO
- [x] Add verbose mode which logging the took time to iteration and ~~expected finish time~~.