### PR TITLE
Support state sequence handling of DQN

### DIFF
--- a/kyoka/value_function/base_deep_q_learning_action_value_function.py
+++ b/kyoka/value_function/base_deep_q_learning_action_value_function.py
@@ -10,8 +10,8 @@ class BaseDeepQLearningActionValueFunction(BaseActionValueFunction):
     err_msg = self.__build_not_implemented_message("deepcopy_network")
     raise NotImplementedError(err_msg)
 
-  def preprocess_state(self, state):
-    err_msg = self.__build_not_implemented_message("preprocess_state")
+  def preprocess_state_sequence(self, raw_state_sequence):
+    err_msg = self.__build_not_implemented_message("preprocess_state_sequence")
     raise NotImplementedError(err_msg)
 
   def predict_action_value(self, network, processed_state, action):

--- a/sample/maze/maze_dqn_value_function.py
+++ b/sample/maze/maze_dqn_value_function.py
@@ -28,8 +28,8 @@ class MazeDQNValueFunction(BaseDeepQLearningActionValueFunction):
     os.remove(tmp_file_path)
     return target_network
 
-  def preprocess_state(self, state):
-    return state
+  def preprocess_state_sequence(self, raw_state_sequence):
+    return raw_state_sequence[-1]
 
   def predict_action_value(self, q_network, processed_state, action):
     X = self.__transform_state_action_into_input(processed_state, action)

--- a/sample/ticktacktoe/ticktacktoe_dqn_value_function.py
+++ b/sample/ticktacktoe/ticktacktoe_dqn_value_function.py
@@ -28,8 +28,8 @@ class TickTackToeDQNValueFunction(BaseDeepQLearningActionValueFunction):
     os.remove(tmp_file_path)
     return target_network
 
-  def preprocess_state(self, state):
-    return state
+  def preprocess_state_sequence(self, raw_state_sequence):
+    return raw_state_sequence[-1]
 
   def predict_action_value(self, q_network, processed_state, action):
     X = self.__transform_state_action_into_input(processed_state, action)

--- a/tests/kyoka/value_function/base_deep_q_learning_action_value_function_test.py
+++ b/tests/kyoka/value_function/base_deep_q_learning_action_value_function_test.py
@@ -28,10 +28,10 @@ class BaseDeepQLearningActionValueFunctionTest(BaseUnitTest):
       self.func.deepcopy_network("dummy")
     self.include("deepcopy_network", e.exception.message)
 
-  def test_preprocess_state(self):
+  def test_preprocess_state_sequence(self):
     with self.assertRaises(NotImplementedError) as e:
-      self.func.preprocess_state("dummy")
-    self.include("preprocess_state", e.exception.message)
+      self.func.preprocess_state_sequence("dummy")
+    self.include("preprocess_state_sequence", e.exception.message)
 
   def test_predict_action_value(self):
     with self.assertRaises(NotImplementedError) as e:


### PR DESCRIPTION
Current implementation does not support *preprocess state sequence* 
which used in the original paper as symbol *phi*.
So implement it.
(Original issue https://github.com/ishikota/kyoka/issues/20)