### PR TITLE
Code style

### DIFF
--- a/kyoka/algorithm/deep_q_learning.py
+++ b/kyoka/algorithm/deep_q_learning.py
@@ -6,6 +6,7 @@ from kyoka.policy import GreedyPolicy, EpsilonGreedyPolicy
 from kyoka.value_function import BaseApproxActionValueFunction
 from kyoka.algorithm.rl_algorithm import BaseRLAlgorithm, generate_episode
 
+
 class DeepQLearning(BaseRLAlgorithm):
 
     SAVE_FILE_NAME = "dq_replay_memory.pickle"

--- a/kyoka/algorithm/deep_q_learning.py
+++ b/kyoka/algorithm/deep_q_learning.py
@@ -11,7 +11,9 @@ class DeepQLearning(BaseRLAlgorithm):
 
     SAVE_FILE_NAME = "dq_replay_memory.pickle"
 
-    def __init__(self, gamma=0.99, N=1000000, C=10000, minibatch_size=32, replay_start_size=50000):
+    def __init__(self, gamma=0.99, N=1000000, C=10000,
+            minibatch_size=32, replay_start_size=50000):
+
         self.gamma = gamma
         self.replay_memory = ExperienceReplay(max_size=N)
         self.C = C
@@ -37,7 +39,8 @@ class DeepQLearning(BaseRLAlgorithm):
             state = next_state
 
             experience_minibatch = self.replay_memory.sample_minibatch(self.minibatch_size)
-            backup_minibatch = self._gen_backup_minibatch(task, self.greedy_policy, value_function, experience_minibatch)
+            backup_minibatch = self._gen_backup_minibatch(
+                    task, self.greedy_policy, value_function, experience_minibatch)
             value_function.backup_on_minibatch(value_function.q_network, backup_minibatch)
 
             if self.reset_step_counter >= self.C:
@@ -55,8 +58,8 @@ class DeepQLearning(BaseRLAlgorithm):
 
     def load_algorithm_state(self, load_dir_path):
         state = unpickle_data(self._gen_replay_memory_save_path(load_dir_path))
-        self.gamma, replay_memory_serial, self.C, self.minibatch_size,\
-                self.replay_start_size, self.reset_step_counter = state
+        (self.gamma, replay_memory_serial, self.C, self.minibatch_size,
+                self.replay_start_size, self.reset_step_counter) = state
         self.greedy_policy = GreedyPolicy()
         new_replay_memory = ExperienceReplay(max_size=1)
         new_replay_memory.load(replay_memory_serial)
@@ -64,7 +67,8 @@ class DeepQLearning(BaseRLAlgorithm):
 
     def _gen_backup_minibatch(self, task, greedy_policy, value_function, experience_minibatch):
         value_function.use_target_network(True)
-        backup_minibatch = [self._gen_backup_data(task, greedy_policy, value_function, experience)\
+        backup_minibatch = [
+                self._gen_backup_data(task, greedy_policy, value_function, experience)
                 for experience in experience_minibatch]
         value_function.use_target_network(False)
         return backup_minibatch
@@ -151,7 +155,8 @@ class ExperienceReplay(object):
 def initialize_replay_memory(task, value_function, replay_memory, start_size):
     random_policy = EpsilonGreedyPolicy(eps=1.0)
     while len(replay_memory.queue) < start_size:
-        for state, action, next_state, reward in generate_episode(task, random_policy, value_function):
+        episode = generate_episode(task, random_policy, value_function)
+        for state, action, next_state, reward in episode:
             replay_memory.store_transition(state, action, reward, next_state)
             if len(replay_memory.queue) >= start_size: return
 
@@ -170,7 +175,7 @@ def predict_value(value_function, next_state, next_action):
         return value_function.predict_value(next_state, next_action)
 
 def validate_value_function(value_function):
-    value_function_check("DeepQLearning",\
-            [DeepQLearningApproxActionValueFunction],\
+    value_function_check("DeepQLearning",
+            [DeepQLearningApproxActionValueFunction],
             value_function)
 

--- a/kyoka/algorithm/montecarlo.py
+++ b/kyoka/algorithm/montecarlo.py
@@ -4,6 +4,7 @@ from kyoka.utils import pickle_data, unpickle_data, value_function_check
 from kyoka.value_function import BaseTabularActionValueFunction, BaseApproxActionValueFunction
 from kyoka.algorithm.rl_algorithm import BaseRLAlgorithm, generate_episode
 
+
 class MonteCarlo(BaseRLAlgorithm):
 
     def __init__(self, gamma=1):

--- a/kyoka/algorithm/montecarlo.py
+++ b/kyoka/algorithm/montecarlo.py
@@ -47,7 +47,9 @@ class MonteCarloTabularActionValueFunction(BaseTabularActionValueFunction):
     def load(self, load_dir_path):
         super(MonteCarloTabularActionValueFunction, self).load(load_dir_path)
         if not os.path.exists(self._gen_update_counter_file_path(load_dir_path)):
-            raise IOError('The saved data of "MonteCarlo" algorithm is not found in [ %s ]'% load_dir_path)
+            raise IOError(
+                    'The saved data of "MonteCarlo" algorithm is not found in [ %s ]' %
+                    load_dir_path)
         self.update_counter = unpickle_data(self._gen_update_counter_file_path(load_dir_path))
 
     def backup(self, state, action, backup_target, alpha):
@@ -67,7 +69,7 @@ class MonteCarloApproxActionValueFunction(BaseApproxActionValueFunction):
     pass
 
 def validate_value_function(value_function):
-    value_function_check("MonteCarlo",\
-            [MonteCarloTabularActionValueFunction, MonteCarloApproxActionValueFunction],\
+    value_function_check("MonteCarlo",
+            [MonteCarloTabularActionValueFunction, MonteCarloApproxActionValueFunction],
             value_function)
 

--- a/kyoka/algorithm/montecarlo_tree_search.py
+++ b/kyoka/algorithm/montecarlo_tree_search.py
@@ -1,7 +1,9 @@
 import random
 import math
+
 from kyoka.utils import build_not_implemented_msg
 from kyoka.task import BaseTask
+
 
 class BaseMCTS(object):
 

--- a/kyoka/algorithm/montecarlo_tree_search.py
+++ b/kyoka/algorithm/montecarlo_tree_search.py
@@ -29,10 +29,11 @@ class BaseMCTS(object):
 
     def planning(self, state, finish_rule):
         assert not self.task.is_terminal_state(state)
-        finish_rule.log(finish_rule.generate_start_message().replace("GPI", "MCTS"))
+        _log_start_msg(finish_rule)
         iteration_count = 0
 
-        root_node = self.generate_node_from_state(state)  # TODO use last calculation result like AlphaGo
+        # TODO use last calculation result like AlphaGo
+        root_node = self.generate_node_from_state(state)
         while not finish_rule.check_condition(iteration_count, self.task, None):
             finish_rule.before_update(iteration_count, self.task, None)
 
@@ -49,11 +50,12 @@ class BaseMCTS(object):
             iteration_count += 1
 
         self.last_calculated_tree = root_node
-        finish_rule.log(finish_rule.generate_finish_message(iteration_count).replace("GPI", "MCTS"))
+        _log_finish_msg(finish_rule, iteration_count)
         return root_node.select_best_edge().action
 
     def _select(self, root_node):
         target_node = root_node
+        # FIXME move this logic to BaseNode class as expandable property
         while not self.task.is_terminal_state(target_node.state) and not target_node.has_unvisited_edge():
             target_node = target_node.select_best_edge().child_node
         return target_node
@@ -84,6 +86,12 @@ def random_playout(task, leaf_node, rand=random):
         state = task.transit_state(state, action)
     return task.calculate_reward(state)
 
+def _log_start_msg(finish_rule):
+    finish_rule.log(finish_rule.generate_start_message().replace("GPI", "MCTS"))
+
+def _log_finish_msg(finish_rule, iteration_count):
+    fin_msg= finish_rule.generate_finish_message(iteration_count)
+    finish_rule.log(fin_msg.replace("GPI", "MCTS"))
 
 class BaseNode(object):
 

--- a/kyoka/algorithm/montecarlo_tree_search.py
+++ b/kyoka/algorithm/montecarlo_tree_search.py
@@ -55,13 +55,12 @@ class BaseMCTS(object):
 
     def _select(self, root_node):
         target_node = root_node
-        # FIXME move this logic to BaseNode class as expandable property
-        while not self.task.is_terminal_state(target_node.state) and not target_node.has_unvisited_edge():
+        while target_node.is_expanded:
             target_node = target_node.select_best_edge().child_node
         return target_node
 
     def _expand(self, node):
-        assert node.has_unvisited_edge()
+        assert node.has_unvisited_edge
         edge = node.select_unvisited_edge()
         edge.build_child(self.generate_node_from_state)
         return edge.child_node
@@ -75,7 +74,7 @@ class BaseMCTS(object):
         assert target.parent_edge is not None
         while target.parent_edge:
             target.parent_edge.visit()
-            target.parent_edge.update_value(reward)
+            target.parent_edge.update_internal_value(reward)
             target = target.parent_edge.parent_node
 
 def random_playout(task, leaf_node, rand=random):
@@ -100,6 +99,7 @@ class BaseNode(object):
         self.state = state
         self.parent_edge = None
         self.child_edges = self.build_child_edges(task, state)
+        self.terminal = task.is_terminal_state(state)
 
     def generate_edge(self, parent_node, action):
         err_msg = build_not_implemented_msg(self, "generate_edge")
@@ -115,12 +115,18 @@ class BaseNode(object):
         actions = task.generate_possible_actions(state)
         return [self.generate_edge(self, action) for action in actions]
 
-    def has_unvisited_edge(self):
-        return any([not edge.has_child() for edge in self.child_edges])
-
     def select_unvisited_edge(self):
-        return [edge for edge in self.child_edges if not edge.has_child()][0]
+        return [edge for edge in self.child_edges if not edge.has_child][0]
 
+    @property
+    def is_expanded(self):
+        return not (self.terminal or self.has_unvisited_edge)
+
+    @property
+    def has_unvisited_edge(self):
+        return any([not edge.has_child for edge in self.child_edges])
+
+    @property
     def visit_count(self):
         return sum([edge.visit_count for edge in self.child_edges])
 
@@ -132,16 +138,13 @@ class BaseEdge(object):
         self.child_node = None
         self.visit_count = 0
 
-    def update_value(self, new_reward):
-        err_msg = build_not_implemented_msg(self, "update_value")
+    def update_internal_value(self, new_reward):
+        err_msg = build_not_implemented_msg(self, "update_internal_value")
         raise NotImplementedError(err_msg)
 
     def calculate_value(self):
         err_msg = build_not_implemented_msg(self, "calculate_value")
         raise NotImplementedError(err_msg)
-
-    def has_child(self):
-        return self.child_node is not None
 
     def build_child(self, state2node):
         child_state = self.parent_node.task.transit_state(self.parent_node.state, self.action)
@@ -150,6 +153,10 @@ class BaseEdge(object):
 
     def visit(self):
         self.visit_count += 1
+
+    @property
+    def has_child(self):
+        return self.child_node is not None
 
 class UCTNode(BaseNode):
 
@@ -161,17 +168,18 @@ class UCTEdge(BaseEdge):
     def __init__(self, parent_node, action):
         super(UCTEdge, self).__init__(parent_node, action)
         self.C = 1.4142135623730951  # 1.41... = math.sqrt(2)
-        self.value = 0
+        self.internal_value = 0
 
-    def update_value(self, new_reward):
-        self.value = self._calc_average_in_incremental_way(self.value, self.visit_count, new_reward)
+    def update_internal_value(self, new_reward):
+        self.internal_value = self._calc_average_in_incremental_way(
+                self.internal_value, self.visit_count, new_reward)
 
     def calculate_value(self):
         if self.visit_count == 0:
             explore_term = float('inf')
         else:
-            explore_term = math.sqrt(math.log(self.parent_node.visit_count()) / self.visit_count)
-        return self.value + self.C * explore_term
+            explore_term = math.sqrt(math.log(self.parent_node.visit_count) / self.visit_count)
+        return self.internal_value + self.C * explore_term
 
     def _calc_average_in_incremental_way(self, old_value, visit_count, new_reward):
         assert visit_count != 0

--- a/kyoka/algorithm/q_learning.py
+++ b/kyoka/algorithm/q_learning.py
@@ -5,6 +5,7 @@ from kyoka.policy import GreedyPolicy
 from kyoka.value_function import BaseTabularActionValueFunction, BaseApproxActionValueFunction
 from kyoka.algorithm.rl_algorithm import BaseRLAlgorithm
 
+
 class QLearning(BaseRLAlgorithm):
 
     def __init__(self, alpha=0.1, gamma=0.9):

--- a/kyoka/algorithm/q_learning.py
+++ b/kyoka/algorithm/q_learning.py
@@ -58,7 +58,7 @@ def predict_value(value_function, next_state, next_action):
         return value_function.predict_value(next_state, next_action)
 
 def validate_value_function(value_function):
-    value_function_check("QLearning",\
-            [QLearningTabularActionValueFunction, QLearningApproxActionValueFunction],\
+    value_function_check("QLearning",
+            [QLearningTabularActionValueFunction, QLearningApproxActionValueFunction],
             value_function)
 

--- a/kyoka/algorithm/rl_algorithm.py
+++ b/kyoka/algorithm/rl_algorithm.py
@@ -2,6 +2,7 @@ from kyoka.utils import build_not_implemented_msg
 from kyoka.policy import EpsilonGreedyPolicy
 from kyoka.callback import EpsilonAnnealer, WatchIterationCount
 
+
 def generate_episode(task, policy, value_function):
     state = task.generate_initial_state()
     episode = []

--- a/kyoka/algorithm/sarsa.py
+++ b/kyoka/algorithm/sarsa.py
@@ -55,7 +55,7 @@ def predict_value(value_function, next_state, next_action):
         return value_function.predict_value(next_state, next_action)
 
 def validate_value_function(value_function):
-    value_function_check("Sarsa",\
-            [SarsaTabularActionValueFunction, SarsaApproxActionValueFunction],\
+    value_function_check("Sarsa",
+            [SarsaTabularActionValueFunction, SarsaApproxActionValueFunction],
             value_function)
 

--- a/kyoka/algorithm/sarsa.py
+++ b/kyoka/algorithm/sarsa.py
@@ -4,6 +4,7 @@ from kyoka.utils import value_function_check
 from kyoka.value_function import BaseTabularActionValueFunction, BaseApproxActionValueFunction
 from kyoka.algorithm.rl_algorithm import BaseRLAlgorithm, generate_episode
 
+
 class Sarsa(BaseRLAlgorithm):
 
     def __init__(self, alpha=0.1, gamma=0.9):

--- a/kyoka/callback.py
+++ b/kyoka/callback.py
@@ -6,27 +6,27 @@ from utils import build_not_implemented_msg
 
 class BaseCallback(object):
 
-  def before_gpi_start(self, task, value_function):
-    pass
+    def before_gpi_start(self, task, value_function):
+        pass
 
-  def before_update(self, iteration_count, task, value_function):
-    pass
+    def before_update(self, iteration_count, task, value_function):
+        pass
 
-  def after_update(self, iteration_count, task, value_function):
-    pass
+    def after_update(self, iteration_count, task, value_function):
+        pass
 
-  def after_gpi_finish(self, task, value_function):
-    pass
+    def after_gpi_finish(self, task, value_function):
+        pass
 
-  def interrupt_gpi(self, iteration_count, task, value_function):
-    return False
+    def interrupt_gpi(self, iteration_count, task, value_function):
+        return False
 
-  def define_log_tag(self):
-    return self.__class__.__name__
+    def define_log_tag(self):
+        return self.__class__.__name__
 
-  def log(self, message):
-    if message and len(message) != 0:
-      print "[%s] %s" % (self.define_log_tag(), message)
+    def log(self, message):
+        if message and len(message) != 0:
+            print "[%s] %s" % (self.define_log_tag(), message)
 
 class BasePerformanceWatcher(BaseCallback):
 

--- a/kyoka/callback.py
+++ b/kyoka/callback.py
@@ -24,9 +24,13 @@ class BaseCallback(object):
     def define_log_tag(self):
         return self.__class__.__name__
 
+    @property
+    def tag(self):
+        return self.define_log_tag()
+
     def log(self, message):
         if message and len(message) != 0:
-            print "[%s] %s" % (self.define_log_tag(), message)
+            print "[%s] %s" % (self.tag, message)
 
 class BasePerformanceWatcher(BaseCallback):
 

--- a/kyoka/callback.py
+++ b/kyoka/callback.py
@@ -1,6 +1,8 @@
 import os
 import time
+
 from utils import build_not_implemented_msg
+
 
 class BaseCallback(object):
 

--- a/kyoka/callback.py
+++ b/kyoka/callback.py
@@ -209,8 +209,9 @@ class WatchIterationCount(BaseFinishRule):
         super(WatchIterationCount, self).after_update(iteration_count, task, value_function)
         if self.verbose > 0:
             current_time = time.time()
-            msg = "Finished %d / %d iterations (%.1fs)" %\
-                    (iteration_count, self.target_count, current_time - self.last_update_time)
+            msg = "Finished %d / %d iterations (%.1fs)" % (
+                    iteration_count, self.target_count,
+                    current_time - self.last_update_time)
             self.last_update_time = current_time
             self.log(msg)
 

--- a/kyoka/policy.py
+++ b/kyoka/policy.py
@@ -2,6 +2,7 @@ import random
 
 from kyoka.utils import build_not_implemented_msg
 
+
 def choose_best_action(task, value_function, state, rand=None):
     rand = rand if rand else random
     actions = task.generate_possible_actions(state)

--- a/kyoka/task.py
+++ b/kyoka/task.py
@@ -1,5 +1,6 @@
 from utils import build_not_implemented_msg
 
+
 class BaseTask(object):
 
   def generate_inital_state(self):

--- a/kyoka/utils.py
+++ b/kyoka/utils.py
@@ -1,5 +1,6 @@
 import pickle
 
+
 def build_not_implemented_msg(instance, method_name):
     base_msg = "[ {0} ] class does not implement [ {1} ] method"
     return base_msg.format(instance.__class__.__name__, method_name)

--- a/kyoka/value_function.py
+++ b/kyoka/value_function.py
@@ -1,5 +1,7 @@
 import os
+
 from kyoka.utils import build_not_implemented_msg, pickle_data, unpickle_data
+
 
 class BaseActionValueFunction(object):
 

--- a/kyoka/value_function.py
+++ b/kyoka/value_function.py
@@ -54,7 +54,8 @@ class BaseTabularActionValueFunction(BaseActionValueFunction):
     def load(self, load_dir_path):
         file_path = self._gen_table_data_file_path(load_dir_path)
         if not os.path.exists(file_path):
-            raise IOError('The saved data of "TableActionValueFunction" is not found on [ %s ]' % load_dir_path)
+            raise IOError('The saved data of "TableActionValueFunction"' +
+                          ' is not found on [ %s ]' % load_dir_path)
         self.table = unpickle_data(file_path)
 
     def _gen_table_data_file_path(self, dir_path):

--- a/tests/base_unittest.py
+++ b/tests/base_unittest.py
@@ -1,5 +1,6 @@
 import unittest
 
+
 class BaseUnitTest(unittest.TestCase):
 
   def eq(self, expected, target):

--- a/tests/examples/maze/helper_test.py
+++ b/tests/examples/maze/helper_test.py
@@ -1,9 +1,10 @@
 import os
-import examples.maze.helper as H
 
-from tests.base_unittest import BaseUnitTest
+import examples.maze.helper as H
 from kyoka.value_function import BaseActionValueFunction
 from examples.maze.task import MazeTask
+from tests.base_unittest import BaseUnitTest
+
 
 class MazeHelperTest(BaseUnitTest):
 

--- a/tests/examples/maze/task_test.py
+++ b/tests/examples/maze/task_test.py
@@ -1,8 +1,10 @@
 import os
 
 from nose.tools import raises
-from tests.base_unittest import BaseUnitTest
+
 from examples.maze.task import MazeTask
+from tests.base_unittest import BaseUnitTest
+
 
 class MazeTaskTest(BaseUnitTest):
 

--- a/tests/examples/ticktacktoe/helper_test.py
+++ b/tests/examples/ticktacktoe/helper_test.py
@@ -1,7 +1,7 @@
 import examples.ticktacktoe.helper as H
-
-from tests.base_unittest import BaseUnitTest
 from examples.ticktacktoe.task import TickTackToeTask
+from tests.base_unittest import BaseUnitTest
+
 
 class TickTackToeHelperTest(BaseUnitTest):
 

--- a/tests/examples/ticktacktoe/task_test.py
+++ b/tests/examples/ticktacktoe/task_test.py
@@ -1,5 +1,6 @@
-from tests.base_unittest import BaseUnitTest
 from examples.ticktacktoe.task import TickTackToeTask
+from tests.base_unittest import BaseUnitTest
+
 
 class TickTackToeTaskTest(BaseUnitTest):
     """

--- a/tests/kyoka/algorithm/deep_q_learning_test.py
+++ b/tests/kyoka/algorithm/deep_q_learning_test.py
@@ -1,14 +1,15 @@
 import os
 
 from nose.tools import raises
-from tests.base_unittest import BaseUnitTest
-from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir, NegativePolicy
 from mock import patch, Mock
 
 from kyoka.utils import pickle_data, unpickle_data
 from kyoka.policy import GreedyPolicy
 from kyoka.algorithm.deep_q_learning import DeepQLearning,\
         DeepQLearningApproxActionValueFunction, ExperienceReplay
+from tests.base_unittest import BaseUnitTest
+from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir, NegativePolicy
+
 
 class DeepQLearningTest(BaseUnitTest):
 

--- a/tests/kyoka/algorithm/montecarlo_test.py
+++ b/tests/kyoka/algorithm/montecarlo_test.py
@@ -1,14 +1,15 @@
-from tests.base_unittest import BaseUnitTest
-from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir
-from kyoka.algorithm.montecarlo import MonteCarlo, MonteCarloTabularActionValueFunction,\
-        MonteCarloApproxActionValueFunction, validate_value_function
-from kyoka.value_function import BaseActionValueFunction
-from kyoka.policy import GreedyPolicy
+import os
 
 from mock import Mock
 from nose.tools import raises
 
-import os
+from kyoka.algorithm.montecarlo import MonteCarlo, MonteCarloTabularActionValueFunction,\
+        MonteCarloApproxActionValueFunction, validate_value_function
+from kyoka.value_function import BaseActionValueFunction
+from kyoka.policy import GreedyPolicy
+from tests.base_unittest import BaseUnitTest
+from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir
+
 
 class MonteCarloTest(BaseUnitTest):
 

--- a/tests/kyoka/algorithm/montecarlo_tree_search_test.py
+++ b/tests/kyoka/algorithm/montecarlo_tree_search_test.py
@@ -1,9 +1,11 @@
 from mock import patch
-from tests.base_unittest import BaseUnitTest
+
 from kyoka.task import BaseTask
 from kyoka.algorithm.montecarlo_tree_search import BaseMCTS, BaseNode, BaseEdge,\
         UCTNode, UCTEdge, random_playout
 from kyoka.callback import WatchIterationCount
+from tests.base_unittest import BaseUnitTest
+
 
 class MCTSTest(BaseUnitTest):
 

--- a/tests/kyoka/algorithm/q_learning_test.py
+++ b/tests/kyoka/algorithm/q_learning_test.py
@@ -1,11 +1,12 @@
-from tests.base_unittest import BaseUnitTest
-from tests.utils import NegativePolicy
 from mock import Mock
 from nose.tools import raises
 
 from kyoka.value_function import BaseActionValueFunction
 from kyoka.algorithm.q_learning import QLearning, QLearningTabularActionValueFunction,\
         QLearningApproxActionValueFunction, validate_value_function
+from tests.base_unittest import BaseUnitTest
+from tests.utils import NegativePolicy
+
 
 class QLearningTest(BaseUnitTest):
 

--- a/tests/kyoka/algorithm/rl_algorithm_test.py
+++ b/tests/kyoka/algorithm/rl_algorithm_test.py
@@ -1,13 +1,14 @@
-from tests.base_unittest import BaseUnitTest
+import StringIO
+import sys
+
+from mock import Mock
+
 from kyoka.algorithm.rl_algorithm import BaseRLAlgorithm, generate_episode
 from kyoka.policy import GreedyPolicy, EpsilonGreedyPolicy
 from kyoka.value_function import BaseActionValueFunction
 from kyoka.callback import BaseFinishRule
+from tests.base_unittest import BaseUnitTest
 
-from mock import Mock
-
-import StringIO
-import sys
 
 class BaseRLAlgorithmTest(BaseUnitTest):
 

--- a/tests/kyoka/algorithm/sarsa_test.py
+++ b/tests/kyoka/algorithm/sarsa_test.py
@@ -1,13 +1,14 @@
 import os
 
-from tests.base_unittest import BaseUnitTest
-from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir, NegativePolicy
 from mock import Mock
 from nose.tools import raises
 
 from kyoka.value_function import BaseActionValueFunction
 from kyoka.algorithm.sarsa import Sarsa, SarsaTabularActionValueFunction,\
         SarsaApproxActionValueFunction, validate_value_function
+from tests.base_unittest import BaseUnitTest
+from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir, NegativePolicy
+
 
 class SarsaTest(BaseUnitTest):
 

--- a/tests/kyoka/callback_test.py
+++ b/tests/kyoka/callback_test.py
@@ -2,13 +2,15 @@ import os
 import sys
 import StringIO
 
-from tests.base_unittest import BaseUnitTest
-from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir, remove_leaf_dir
 from nose.tools import raises
 from mock import patch, Mock
+
 from kyoka.callback import BaseCallback, BasePerformanceWatcher, EpsilonAnnealer,\
         LearningRecorder, BaseFinishRule, ManualInterruption, WatchIterationCount
 from kyoka.policy import EpsilonGreedyPolicy
+from tests.base_unittest import BaseUnitTest
+from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir, remove_leaf_dir
+
 
 def capture_log(instance):
     instance.capture = StringIO.StringIO()

--- a/tests/kyoka/policy_test.py
+++ b/tests/kyoka/policy_test.py
@@ -1,7 +1,9 @@
-from tests.base_unittest import BaseUnitTest
-from kyoka.policy import BasePolicy, GreedyPolicy, EpsilonGreedyPolicy
 from nose.tools import raises
 from mock import Mock
+
+from kyoka.policy import BasePolicy, GreedyPolicy, EpsilonGreedyPolicy
+from tests.base_unittest import BaseUnitTest
+
 
 class BasePolityTest(BaseUnitTest):
 

--- a/tests/kyoka/task_test.py
+++ b/tests/kyoka/task_test.py
@@ -1,6 +1,8 @@
-from tests.base_unittest import BaseUnitTest
-from kyoka.task import BaseTask
 from nose.tools import raises
+
+from kyoka.task import BaseTask
+from tests.base_unittest import BaseUnitTest
+
 
 class BaseTaskTest(BaseUnitTest):
 

--- a/tests/kyoka/utils_test.py
+++ b/tests/kyoka/utils_test.py
@@ -1,6 +1,7 @@
 import kyoka.utils as U
 from tests.base_unittest import BaseUnitTest
 
+
 class UtilsTest(BaseUnitTest):
 
     def test_build_not_implemented_msg(self):

--- a/tests/kyoka/value_function_test.py
+++ b/tests/kyoka/value_function_test.py
@@ -1,8 +1,11 @@
 import os
+
+from nose.tools import raises
+
+from kyoka.value_function import BaseTabularActionValueFunction, BaseApproxActionValueFunction
 from tests.base_unittest import BaseUnitTest
 from tests.utils import generate_tmp_dir_path, setup_tmp_dir, teardown_tmp_dir
-from kyoka.value_function import BaseTabularActionValueFunction, BaseApproxActionValueFunction
-from nose.tools import raises
+
 
 class BaseTabularActionValueFunctionTest(BaseUnitTest):
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
 import os
+
 from kyoka.policy import BasePolicy
+
 
 def generate_tmp_dir_path(script_path):
     return os.path.join(os.path.dirname(script_path), "tmp")


### PR DESCRIPTION
Refactor code style by following Google Python StyleGuide
http://works.surgo.jp/translation/pyguide.html#id8

what changed
- code style of import sentence
```
import system_module

import 3rd_party_module

import my_module

# start module code after 2 empty line
```

- do not use ＼ to go to new line
```
# before
self.gamma, replay_memory_serial, self.C, self.minibatch_size,\
        self.replay_start_size, self.reset_step_counter = state
# after
(self.gamma, replay_memory_serial, self.C, self.minibatch_size,
        self.replay_start_size, self.reset_step_counter) = state
```

- do not over 100 chars in one line as possible
```
# before
backup_minibatch = self._gen_backup_minibatch(task, self.greedy_policy, value_function, experience_minibatch)
# after
backup_minibatch = self._gen_backup_minibatch(
        task, self.greedy_policy, value_function, experience_minibatch)
```
- use property decorator
```
# before
def has_unvisited_edge(self):
    return any([not edge.has_child() for edge in self.child_edges])
if node.has_unvisited_edge(): do_something()
# after
@property
def has_unvisited_edge(self):
    return any([not edge.has_child() for edge in self.child_edges])
if node.has_unvisited_edge: do_something()
```